### PR TITLE
Add URL bar search suggestion remarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,6 @@ In addition to the `userChrome.css` and `userContent.css` files you'll also need
 #### With URL Bar:
 
 ![](https://github.com/MiguelRAvila/SimplerentFox/blob/master/Images/FirefoxCUB.png)
+
+### Hiding "This time, search with" URL bar message
+Hiding the message can give a more minimalistic URL bar. To hide the message additional search engines need to be removed, which can be done throught the _One-Click Search Engines_ option in the [Settings' Search tab](about:preferences#search).


### PR DESCRIPTION
I noticed that my browser still had a section underneath my URL bar containing suggestions which search engine to use. Given the minimalistic style of this repo I think it would fit to give users some direction on how to remove this as well. 

I know it's not entirely the responsibility of this repo to tell people about it, but I thought it might save some people a google search. 

Let me know what you think!